### PR TITLE
Support for variable world size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # ant-life
 
- A game with bugs
+A game with bugs
 
 https://davidralph.github.io/ant-life/
+
+Ant Life is a web game inspired by [Powder Game](https://dan-ball.jp/en/javagame/dust/)
+and [Conway's Game of Life](https://en.wikipedia.org/wiki/Conway's_Game_of_Life),
+but instead simulates the behaviour of ants and their environment.
+
+By placing and clearing tiles and guiding ants using pheromone trails you can help
+them farm plants and fungus, which queens will consume to lay eggs. To achieve
+a high score, design your colony to maximise sustainable growth and avoid deadly
+hazards like water and pests.
+
+Ant Life works on desktop and mobile, but may lag on older phones due to the
+complexity and implementation of the simulation.
+
+Ant Life is implemented in JavaScript using Canvas. 
+
+Check out the [WASM accelerated fork](https://github.com/JavaRip/ant-life-optimised/)

--- a/script/definitions.js
+++ b/script/definitions.js
@@ -1,9 +1,9 @@
-let DEBUG = false;
-let BENCHMARK_TICKS = 100;
-let BENCHMARK_BATCHES = 10;
-let BENCHMARK_DENSITY = 0.05;
+let DEBUG = false; // Show debug info in the console
+let BENCHMARK_TICKS = 100; // Number of simulation steps to run the benchmark for
+let BENCHMARK_BATCHES = 10; // Benchmarks are averaged over this many runs
+let BENCHMARK_DENSITY = 0.05; // Proportion of tiles that are not air in benchmark worlds, this ensures tiles can move around
 
-const TPS = 30;
+const TPS = 30; // Game speed in (max) ticks per second
 const START_PAUSED = false;
 
 const TILESET = {

--- a/script/definitions.js
+++ b/script/definitions.js
@@ -25,8 +25,8 @@ const TILESET = {
 // Tiles that can be overridden with the brush
 const PAINTABLE_MASK = ["AIR", "SOIL", "SAND"];
 
-const ROW_COUNT = 100; // World width
-const COL_COUNT = 100; // World height
+const ROW_COUNT = 100; // World height
+const COL_COUNT = 100; // World width
 const CHUNK_SIZE = 20; // Optimisation for faster searching, must be factor of ROW_COUNT and COL_COUNT
 
 const RAIN_FREQ = 2500; // How often (in game ticks) it rains

--- a/script/definitions.js
+++ b/script/definitions.js
@@ -25,16 +25,17 @@ const TILESET = {
 // Tiles that can be overridden with the brush
 const PAINTABLE_MASK = ["AIR", "SOIL", "SAND"];
 
-const ROW_COUNT = 100; // World height
-const COL_COUNT = 100; // World width
-const CHUNK_SIZE = 20; // Optimisation for faster searching, must be factor of ROW_COUNT and COL_COUNT
-
 const RAIN_FREQ = 2500; // How often (in game ticks) it rains
 const RAIN_TIME = 500; // How long (in game ticks) it rains for
 const PEST_FREQ = 100; // How often (in game ticks) a pest enters the map
 const PEST_START = 4000; // How long (in game ticks) before pests can spawn
 
-// These are modifiable during run-time using the browser console
+// These are modifiable during run-time using the browser console but only take effect after the game is reset
+let ROW_COUNT = 100; // World height
+let COL_COUNT = 100; // World width
+
+// These are modifiable during run-time using the browser console and take effect immediately
+let CHUNK_SIZE = 20; // Optimisation for faster searching, must be factor of ROW_COUNT and COL_COUNT
 let KILL_PROB = 0.01; // Chance per tick for each hazard to kill
 let EVAPORATE_PROB = 0.008; // Chance per tick for water to evaporate
 let CONVERT_PROB = 0.03; // Chance per tick for fungus/plant to convert

--- a/script/game.js
+++ b/script/game.js
@@ -95,6 +95,19 @@ function _setPointerLocation(e) {
 }
 
 function _setBrushMask() {
+  // Starting brushing from outside the map will only paint over AIR
+  if (
+    BRUSH_X < 0 ||
+    BRUSH_X >= WORLD.cols ||
+    BRUSH_Y < 0 ||
+    BRUSH_Y >= WORLD.rows
+  ) {
+    BRUSH_MASK = "AIR";
+    return;
+  }
+
+  // Brush will only paint over tiles of the same type as the first tile clicked
+  // If the first tile clicked is not paintable, the brush will only paint over AIR
   const tile = WORLD.getTile(BRUSH_X, BRUSH_Y);
   if (PAINTABLE_MASK.includes(tile)) {
     BRUSH_MASK = tile;
@@ -180,6 +193,14 @@ function gameLoop(loop = true) {
 
 function doInput(draw = true) {
   if (!BRUSH_ON) return;
+  if (
+    BRUSH_X < 0 ||
+    BRUSH_X >= WORLD.cols ||
+    BRUSH_Y < 0 ||
+    BRUSH_Y >= WORLD.rows
+  ) {
+    return;
+  }
   const brushSize = Math.round($("#brush-size").val());
   const brushMat = $("#brush-mat").val();
   WORLD.fillCircle(BRUSH_X, BRUSH_Y, brushSize, brushMat, BRUSH_MASK);

--- a/script/lib.js
+++ b/script/lib.js
@@ -1,18 +1,42 @@
+/**
+ * Returns whether a point is within a given radius of another point
+ * @param {number} a - X coordinate of the first point
+ * @param {number} b - Y coordinate of the first point
+ * @param {number} x - X coordinate of the second point
+ * @param {number} y - Y coordinate of the second point
+ * @param {number} r - Radius
+ * @returns {boolean} - Whether the first point is within the given radius of the second point
+ */
 function pointWithinRadius(a, b, x, y, r) {
   var dist = (a - x) * (a - x) + (b - y) * (b - y);
   return dist < r * r;
 }
 
+/**
+ * Return a random integer between min and max (inclusive)
+ * @param {number} min - Minimum value
+ * @param {number} max - Maximum value
+ * @returns {number} - Random integer between min and max (inclusive)
+ */
 function randomIntInclusive(min, max) {
   min = Math.ceil(min);
   max = Math.floor(max);
   return Math.floor(Math.random() * (max - min + 1) + min);
 }
 
+/**
+ * Return a random sign (1 or -1)
+ * @returns {number} - 1 or -1
+ */
 function randomSign() {
   return Math.random() < 0.5 ? 1 : -1;
 }
 
+/**
+ * Calculate the average of an array of numbers
+ * @param {number[]} arr - Array of numbers
+ * @returns {number} - Average of the array
+ */
 function average(arr) {
   return arr.reduce((p, c) => p + c, 0) / arr.length;
 }

--- a/script/render.js
+++ b/script/render.js
@@ -4,8 +4,14 @@ class Renderer {
     this.world = world;
     this.tileset = tileset;
     this._ctx = canvas.getContext("2d", { alpha: false });
-    this._cw = canvas.width / world.cols;
-    this._ch = canvas.height / world.rows;
+    // Ensure tiles are square
+    this._tileSize = Math.min(
+      canvas.width / world.cols,
+      canvas.height / world.rows,
+    );
+    // Center the world (letterbox if not square)
+    this._xOffset = (canvas.width - this._tileSize * world.cols) / 2;
+    this._yOffset = (canvas.height - this._tileSize * world.rows) / 2;
     this.fillStyle = "AIR";
   }
 
@@ -27,10 +33,10 @@ class Renderer {
 
         // Draw tile
         this._ctx.fillRect(
-          x * this._cw,
-          this.canvas.height - y * this._ch,
-          this._cw,
-          -this._ch,
+          this._xOffset + x * this._tileSize,
+          this._yOffset + (this.world.rows - y - 1) * this._tileSize,
+          this._tileSize,
+          this._tileSize,
         );
       }
     }
@@ -42,11 +48,11 @@ class Renderer {
     const rect = this.canvas.getBoundingClientRect();
     const scaleX = this.canvas.width / rect.width;
     const scaleY = this.canvas.height / rect.height;
-    const cx = (x - rect.left) * scaleX;
-    const cy = (y - rect.top) * scaleY;
+    const cx = (x - rect.left) * scaleX - this._xOffset;
+    const cy = (y - rect.top) * scaleY - this._yOffset;
     return {
-      x: Math.floor(cx / this._cw),
-      y: this.world.rows - Math.ceil(cy / this._ch),
+      x: Math.floor(cx / this._tileSize),
+      y: this.world.rows - Math.ceil(cy / this._tileSize),
     };
   }
 }

--- a/script/render.js
+++ b/script/render.js
@@ -13,6 +13,8 @@ class Renderer {
     this._xOffset = (canvas.width - this._tileSize * world.cols) / 2;
     this._yOffset = (canvas.height - this._tileSize * world.rows) / 2;
     this.fillStyle = "AIR";
+    // Clear canvas
+    this._ctx.clearRect(0, 0, canvas.width, canvas.height);
   }
 
   draw() {

--- a/script/render.js
+++ b/script/render.js
@@ -17,6 +17,9 @@ class Renderer {
     this._ctx.clearRect(0, 0, canvas.width, canvas.height);
   }
 
+  /**
+   * Draw the current world state. Optimised to only draw changed tiles.
+   */
   draw() {
     /// loop through rows and columns
     for (let y = 0; y < this.world.rows; y++) {
@@ -46,6 +49,12 @@ class Renderer {
     this.oldTiles = JSON.parse(JSON.stringify(this.world.tiles));
   }
 
+  /**
+   * Convert canvas coordinates to world coordinates
+   * @param {number} x - Canvas x coordinate
+   * @param {number} y - Canvas y coordinate
+   * @returns {object} - World coordinates {x, y}
+   */
   mapCoordinates(x, y) {
     const rect = this.canvas.getBoundingClientRect();
     const scaleX = this.canvas.width / rect.width;

--- a/script/world.js
+++ b/script/world.js
@@ -108,7 +108,7 @@ class World {
 
     for (let b = 0; b < this.rows / CHUNK_SIZE; b++) {
       this.chunks.push([]);
-      for (let a = 0; a < this.rows / CHUNK_SIZE; a++) {
+      for (let a = 0; a < this.cols / CHUNK_SIZE; a++) {
         // Create chunk with zeroed counts for all tile types
         let blankChunk = {};
         for (let tile of Object.keys(TILESET)) {
@@ -146,7 +146,7 @@ class World {
 
   forEachTile(minX, minY, maxX, maxY, func) {
     for (let y = Math.max(minY, 0); y <= Math.min(maxY, this.rows - 1); y++) {
-      for (let x = Math.max(minX, 0); x <= Math.min(maxX, this.rows - 1); x++) {
+      for (let x = Math.max(minX, 0); x <= Math.min(maxX, this.cols - 1); x++) {
         func(x, y);
       }
     }

--- a/script/world.js
+++ b/script/world.js
@@ -1,3 +1,11 @@
+/**
+ * Contains the world state and methods for updating it
+ * Tile logic is handled by Worldlogic
+ * Tile generation is handled by Worldgen
+ * @param {number} rows - Number of rows in the world
+ * @param {number} cols - Number of columns in the world
+ * @param {object} generatorSettings - Settings for the world generator
+ */
 class World {
   constructor(rows = ROW_COUNT, cols = COL_COUNT, generatorSettings = {}) {
     this.rows = rows;
@@ -10,6 +18,9 @@ class World {
     this.worldgen.generate(generatorSettings);
   }
 
+  /**
+   * Run the simulation for a single step
+   */
   tick() {
     this._updateChunks();
 
@@ -35,6 +46,11 @@ class World {
     }
   }
 
+  /**
+   * Spawn tiles at random locations on the top row
+   * @param {number} count - number of tiles to spawn
+   * @param {string} tile - tile type to spawn
+   */
   doRain(count, tile = "WATER") {
     // allow for non-int chance
     let realCount = Math.floor(count);
@@ -47,10 +63,24 @@ class World {
     }
   }
 
+  /**
+   * Returns the tile at the given coordinates
+   * @param {number} x - x coordinate
+   * @param {number} y - y coordinate
+   */
   getTile(x, y) {
     return this.tiles[y][x];
   }
 
+  /**
+   * Replaces the tile at the given coordinates
+   * If set, mask will only allow the tile to be set if it is in the mask
+   * @param {number} x - x coordinate
+   * @param {number} y - y coordinate
+   * @param {string} tile - tile type to set
+   * @param {string[]} mask - tile types that are allowed to be replaced
+   * @returns {boolean} - whether the tile was set
+   */
   setTile(x, y, tile, mask = false) {
     if (!this.checkTile(x, y, mask)) {
       return false;
@@ -60,12 +90,28 @@ class World {
     }
   }
 
+  /**
+   * Returns whether a tile is legal and optionally whether it is in the mask
+   * @param {number} x - x coordinate
+   * @param {number} y - y coordinate
+   * @param {string[]} mask - tile types that are allowed
+   * @returns {boolean} - whether the tile is legal and allowed by the mask
+   */
   checkTile(x, y, mask) {
     if (!this._legal(x, y)) return false;
     if (!mask) return true;
     return mask.includes(this.getTile(x, y));
   }
 
+  /**
+   * Returns whether chunks within a given distance of a tile contain a tile in the mask
+   * @param {number} x - x coordinate
+   * @param {number} y - y coordinate
+   * @param {string[]} mask - tile types that are counted
+   * @param {number} distance - distance from tile to check
+   * @param {number} threshold - number of tiles in mask required to return true
+   * @returns {boolean} - whether the chunks contain the required number of tiles
+   */
   checkChunks(x, y, mask, distance = 0, threshold = 1) {
     if (!this._legal(x, y)) return false;
     if (!mask) return true;
@@ -81,6 +127,13 @@ class World {
     return false;
   }
 
+  /**
+   * Returns chunks within a given distance of a tile
+   * @param {number} x - x coordinate
+   * @param {number} y - y coordinate
+   * @param {number} distance - distance from tile to check
+   * @returns {object[]} - chunks within distance of tile
+   */
   _getChunks(x, y, distance) {
     const cxMin = Math.max(0, Math.floor((x - distance) / CHUNK_SIZE));
     const cyMin = Math.max(0, Math.floor((y - distance) / CHUNK_SIZE));
@@ -102,6 +155,9 @@ class World {
     return matches;
   }
 
+  /**
+   * Builds a list of chunks and their tile counts
+   */
   _updateChunks() {
     const me = this;
     this.chunks = [];
@@ -132,6 +188,15 @@ class World {
     }
   }
 
+  /**
+   * Swaps the tiles at the given coordinates if they match the mask
+   * @param {number} x - x coordinate of first tile
+   * @param {number} y - y coordinate of first tile
+   * @param {number} a - x coordinate of second tile
+   * @param {number} b - y coordinate of second tile
+   * @param {string[]} mask - allowed type of second tile
+   * @returns {boolean} - whether the tiles were swapped
+   */
   swapTiles(x, y, a, b, mask = false) {
     if (!this.checkTile(a, b, mask)) {
       return false;
@@ -144,6 +209,14 @@ class World {
     }
   }
 
+  /**
+   * Runs a function on each tile within a given rectangle
+   * @param {number} minX - minimum x coordinate
+   * @param {number} minY - minimum y coordinate
+   * @param {number} maxX - maximum x coordinate
+   * @param {number} maxY - maximum y coordinate
+   * @param {function} func - function to run on each tile
+   */
   forEachTile(minX, minY, maxX, maxY, func) {
     for (let y = Math.max(minY, 0); y <= Math.min(maxY, this.rows - 1); y++) {
       for (let x = Math.max(minX, 0); x <= Math.min(maxX, this.cols - 1); x++) {
@@ -152,6 +225,14 @@ class World {
     }
   }
 
+  /**
+   * Sets all tiles within a given radius of a tile to a given type if they match the mask
+   * @param {number} centerX - x coordinate of center tile
+   * @param {number} centerY - y coordinate of center tile
+   * @param {number} radius - radius of circle
+   * @param {string} tile - type of tile to set
+   * @param {string[]} mask - tile types that are allowed to be replaced
+   */
   fillCircle(centerX, centerY, radius, tile, mask = []) {
     const me = this;
     this.forEachTile(
@@ -167,6 +248,15 @@ class World {
     );
   }
 
+  /**
+   * Sets all tiles within a given rectangle to a given type if they match the mask
+   * @param {number} minX - minimum x coordinate
+   * @param {number} minY - minimum y coordinate
+   * @param {number} maxX - maximum x coordinate
+   * @param {number} maxY - maximum y coordinate
+   * @param {string} tile - type of tile to set
+   * @param {string[]} mask - tile types that are allowed to be replaced
+   */
   fillRectangle(minX, minY, maxX, maxY, tile, mask = []) {
     const me = this;
     this.forEachTile(minX, minY, maxX, maxY, function (x, y) {
@@ -175,17 +265,24 @@ class World {
     });
   }
 
+  /**
+   * Returns whether a pair of coordinates is within the bounds of the map
+   */
   _legal(x, y) {
     return x >= 0 && y >= 0 && x < this.cols && y < this.rows;
   }
 
+  /**
+   * Runs a performance benchmark
+   * @returns {object} - object containing average TPS for a variety of tilesets
+   */
   benchmark() {
-    const durations = {};
+    const scores = {};
     const allTiles = Object.keys(TILESET);
 
     // mixed tilesets
-    durations["all"] = this._doBenchmark(allTiles, "all");
-    durations["creatures"] = this._doBenchmark(
+    scores["all"] = this._doBenchmark(allTiles, "all");
+    scores["creatures"] = this._doBenchmark(
       ["PEST", "WORKER", "EGG", "QUEEN", "AIR"],
       "creatures",
     );
@@ -197,11 +294,11 @@ class World {
       for (let i = 0; i < 1 / BENCHMARK_DENSITY - 1; i++) {
         mask.push("AIR");
       }
-      durations[tile] = this._doBenchmark(mask, tile);
+      scores[tile] = this._doBenchmark(mask, tile);
     }
 
     const sorted = Object.fromEntries(
-      Object.entries(durations).sort(([, a], [, b]) => a - b),
+      Object.entries(scores).sort(([, a], [, b]) => a - b),
     );
     const result = JSON.stringify(sorted, null, 2);
 
@@ -211,6 +308,12 @@ class World {
     return sorted;
   }
 
+  /**
+   * Runs a performance benchmark for a given tile mask
+   * @param {string[]} mask - tile types to benchmark
+   * @param {string} name - name of the benchmark
+   * @returns {number} - average TPS
+   */
   _doBenchmark(mask, name) {
     console.log("Benchmarking", name);
     const batches = [];

--- a/script/world.js
+++ b/script/world.js
@@ -106,26 +106,26 @@ class World {
     const me = this;
     this.chunks = [];
 
-    for (let b = 0; b < this.rows / CHUNK_SIZE; b++) {
+    for (let cy = 0; cy < this.rows / CHUNK_SIZE; cy++) {
       this.chunks.push([]);
-      for (let a = 0; a < this.cols / CHUNK_SIZE; a++) {
+      for (let cx = 0; cx < this.cols / CHUNK_SIZE; cx++) {
         // Create chunk with zeroed counts for all tile types
         let blankChunk = {};
         for (let tile of Object.keys(TILESET)) {
           blankChunk[tile] = 0;
         }
-        this.chunks[b].push(blankChunk);
+        this.chunks[cy].push(blankChunk);
 
         // Count tiles in chunk
-        const b0 = b * CHUNK_SIZE;
-        const a0 = a * CHUNK_SIZE;
+        const cy0 = cy * CHUNK_SIZE;
+        const cx0 = cx * CHUNK_SIZE;
         this.forEachTile(
-          a0,
-          b0,
-          a0 + CHUNK_SIZE,
-          b0 + CHUNK_SIZE,
+          cx0,
+          cy0,
+          cx0 + CHUNK_SIZE,
+          cy0 + CHUNK_SIZE,
           function (x, y) {
-            me.chunks[b][a][me.getTile(x, y)]++;
+            me.chunks[cy][cx][me.getTile(x, y)]++;
           },
         );
       }

--- a/script/worldgen.js
+++ b/script/worldgen.js
@@ -1,8 +1,16 @@
+/**
+ * World generation
+ * @param {World} world - World state object to modify
+ */
 class Worldgen {
   constructor(world) {
     this.world = world;
   }
 
+  /**
+   * Generate a benchmark world with random tiles from the tileset
+   * @param {string[]} mask - Array of tile types to use
+   */
   generateBenchmarkWorld(mask = Object.keys(TILESET)) {
     this.world.age = 0;
     this.world.surfaceY = this.world.rows - 1;
@@ -20,6 +28,35 @@ class Worldgen {
     }
   }
 
+  /**
+   * Generate a world
+   * All options scale with world size, numbers are for a 10000 tile (100x100) world
+   * @param {object} options - World generation options
+   * @param {number} options.skyProp - Proportion of world that is sky
+   * @param {number} options.startingAge - Starting age of world
+   * @param {number} options.startAreaSize - Size of starting area
+   * @param {number} options.sandCount - Number of sand patches
+   * @param {number} options.sandMinSize - Minimum size of sand patches
+   * @param {number} options.sandMaxSize - Maximum size of sand patches
+   * @param {number} options.stoneCount - Number of stone patches
+   * @param {number} options.stoneMinSize - Minimum size of stone patches
+   * @param {number} options.stoneMaxSize - Maximum size of stone patches
+   * @param {number} options.waterCount - Number of water patches
+   * @param {number} options.waterMinSize - Minimum size of water patches
+   * @param {number} options.waterMaxSize - Maximum size of water patches
+   * @param {number} options.hollowCount - Number of hollow patches
+   * @param {number} options.hollowMinSize - Minimum size of hollow patches
+   * @param {number} options.hollowMaxSize - Maximum size of hollow patches
+   * @param {number} options.surfacePlantCount - Number of plants on surface
+   * @param {number} options.plantCount - Number of plants
+   * @param {number} options.fungusCount - Number of fungus patches
+   * @param {number} options.fungusMinSize - Minimum size of fungus patches
+   * @param {number} options.fungusMaxSize - Maximum size of fungus patches
+   * @param {number} options.noiseCount - Number of noise patches
+   * @param {number} options.noiseMinSize - Minimum size of noise patches
+   * @param {number} options.noiseMaxSize - Maximum size of noise patches
+   *
+   */
   generate({
     skyProp = 0.2,
     startingAge = 100,
@@ -112,6 +149,7 @@ class Worldgen {
     );
 
     // Noise (to make shapes less obvious)
+    // These are SOIL patches that can occlude other patches to break up shapes
     this._generatePatches(
       noiseCount,
       surfaceY,
@@ -131,7 +169,7 @@ class Worldgen {
     const plantProb = surfacePlantCount / 100;
     for (let x = 0; x < this.world.cols; x++) {
       if (Math.random() <= plantProb) {
-        this.world.setTile(x, this._findSurfaceY(x)+1, "PLANT");
+        this.world.setTile(x, this._findSurfaceY(x) + 1, "PLANT");
       }
     }
 
@@ -167,6 +205,16 @@ class Worldgen {
     this.world.setTile(midX, surfaceY, "QUEEN");
   }
 
+  /**
+   * Generate a number of patches of a given tile type, with a given size range
+   * count is scaled based on map size (counts are for a 100x100 10000 tile map)
+   * @param {number} count - Number of patches to generate (will be scaled based on map size)
+   * @param {number} maxHeight - Maximum height to generate patches at
+   * @param {number} minSize - Minimum patch size
+   * @param {number} maxSize - Maximum patch size
+   * @param {string} tile - Tile type to generate
+   * @param {string[]} mask - Tile types allowed to be replaced
+   */
   _generatePatches(count, maxHeight, minSize, maxSize, tile, mask) {
     // Scale based on map size (counts are for default 100x100 map)
     const tileCount = this.world.rows * this.world.cols;
@@ -183,6 +231,11 @@ class Worldgen {
     }
   }
 
+  /**
+   * Returns the surface Y coordinate at the given X coordinate
+   * @param {number} x - X coordinate to check
+   * @returns {number} - Y coordinate of the first tile below the given x coordinate that is not AIR or WATER
+   */
   _findSurfaceY(x) {
     for (let y = this.world.rows - 1; y >= 0; y--) {
       if (!this.world.checkTile(x, y, ["AIR", "WATER"])) return y;

--- a/script/worldlogic.js
+++ b/script/worldlogic.js
@@ -1,8 +1,15 @@
+/**
+ * Tile logic for the world
+ * @param {World} world - The world state object to operate on
+ */
 class Worldlogic {
   constructor(world) {
     this.world = world;
   }
 
+  /**
+   * Runs the simulation for a single step
+   */
   tick() {
     this.world.age += 1;
 
@@ -17,6 +24,12 @@ class Worldlogic {
     }
   }
 
+  /**
+   * Perform the action for a tile if it has one
+   * @param {number} x - X coordinate of tile
+   * @param {number} y - Y coordinate of tile
+   * @returns {boolean} - Whether the tile performed an action
+   */
   _doTileAction(x, y) {
     const actions = {
       SAND: this._sandAction,
@@ -39,6 +52,13 @@ class Worldlogic {
     }
   }
 
+  /**
+   * Performs the action for a SAND tile
+   * SAND falls down and to the side
+   * @param {number} x - X coordinate of tile
+   * @param {number} y - Y coordinate of tile
+   * @returns {boolean} - Whether the tile performed an action
+   */
   _sandAction(x, y) {
     // move down or diagonally down
     const bias = randomSign();
@@ -49,6 +69,10 @@ class Worldlogic {
     );
   }
 
+  /**
+   * Performs the action for a CORPSE tile
+   * CORPSE falls down and to the side and has a chance to be converted by adjacent PLANT tiles
+   */
   _corpseAction(x, y) {
     // when touching plant, convert to plant
     if (Math.random() <= CONVERT_PROB * this._touching(x, y, ["PLANT"])) {
@@ -64,7 +88,13 @@ class Worldlogic {
     );
   }
 
+  /**
+   * Performs the action for a WATER tile
+   * WATER falls down and to the side, evaporates under sky or if air to
+   * left/right or near plant, and kills neighbouring creatures
+   */
   _waterAction(x, y) {
+    // chance to kill neighbouring creatures
     if (
       Math.random() <= KILL_PROB &&
       this._setOneTouching(x, y, "CORPSE", WATER_KILL_MASK)
@@ -93,6 +123,11 @@ class Worldlogic {
     );
   }
 
+  /**
+   * Performs the action for a PLANT tile
+   * PLANT falls down when unsupported by adjacent PLANT tiles and has a chance to grow
+   * Growth is less likely when touching other PLANT or FUNGUS tiles so they form narrow stems
+   */
   _plantAction(x, y) {
     // when unsupported, move down
     if (
@@ -118,6 +153,10 @@ class Worldlogic {
     return;
   }
 
+  /**
+   * Performs the action for a FUNGUS tile
+   * FUNGUS falls down and has a chance to convert to adjacent PLANT tiles if underground
+   */
   _fungusAction(x, y) {
     // // Destroyed by air
     // if (Math.random() <= KILL_PROB && this._exposedToSky(x, y)) {
@@ -142,6 +181,13 @@ class Worldlogic {
     return;
   }
 
+  /**
+   * Performs the action for a QUEEN tile
+   * QUEEN falls down when unable to climb. When few FUNGUS tiles are nearby,
+   * QUEEN moves randomly. When adjacent to FUNGUS QUEEN converts it to EGG.
+   * Otherwise QUEEN moves towards closest FUNGUS if any are in range. QUEEN
+   * will not convert FUNGUS if there are too few nearby to avoid extinction.
+   */
   _queenAction(x, y) {
     // when unsupported on all sides, move down
     if (!this._climbable(x, y)) {
@@ -164,6 +210,11 @@ class Worldlogic {
     return false;
   }
 
+  /**
+   * Performs the action for a WORKER tile
+   * WORKER falls down when unable to climb and moves randomly.
+   * When moving randomly, WORKER will push adjacent tiles, spreading them around.
+   */
   _workerAction(x, y) {
     // when unsupported on all sides, move down
     if (!this._climbable(x, y)) {
@@ -174,6 +225,11 @@ class Worldlogic {
     return this._moveRandom(x, y, WALK_MASK, PUSH_MASK);
   }
 
+  /**
+   * Performs the action for a PEST tile
+   * PESTS kill adjacent WORKER, QUEEN, and EGG tiles, seek out targets, or fly around randomly.
+   * PESTS can be killed by adjacent WORKER tiles but usually win a 1-on-1 fight.
+   */
   _pestAction(x, y) {
     // Destroyed by workers
     if (Math.random() <= KILL_PROB * this._touching(x, y, ["WORKER"])) {
@@ -203,6 +259,10 @@ class Worldlogic {
     return this._moveRandom(x, y, ROAM_MASK);
   }
 
+  /**
+   * Performs the action for an EGG tile
+   * EGG falls down and to the side and has a chance to hatch into a QUEEN or WORKER.
+   */
   _eggAction(x, y) {
     // chance to hatch, else move down or diagonally down
     if (Math.random() <= EGG_HATCH_PROB) {
@@ -223,6 +283,12 @@ class Worldlogic {
     );
   }
 
+  /**
+   * Performs the action for a TRAIL tile
+   * TRAIL falls down but is destroyed on contact with anything except air.
+   * TRAIL draws a random WORKER within range (if any) towards it. This is separate
+   * from the WORKER action, so TRAIL lets WORKERs move faster than usual.
+   */
   _trailAction(x, y) {
     let result = false;
 
@@ -265,6 +331,12 @@ class Worldlogic {
     return result;
   }
 
+  /**
+   * Returns whether a tile is climbable
+   * @param {number} x - x coordinate
+   * @param {number} y - y coordinate
+   * @returns {boolean} whether the tile is climbable
+   */
   _climbable(x, y) {
     return (
       !this.world.checkTile(x, y - 1, ["AIR", "TRAIL"]) ||
@@ -272,6 +344,15 @@ class Worldlogic {
     );
   }
 
+  /**
+   * Move in a random direction, switching places with the target tile
+   * or pushing the tile in front if possible
+   * @param {number} x - mover x coordinate
+   * @param {number} y - mover y coordinate
+   * @param {string[]} mask - tile types that can be swapped with
+   * @param {boolean} pushMask - tile types that can be pushed
+   * @returns {boolean} whether tiles were swapped
+   */
   _moveRandom(x, y, mask, pushMask = false) {
     // determine direction
     const dx = randomIntInclusive(-1, 1);
@@ -287,6 +368,12 @@ class Worldlogic {
     return this.world.swapTiles(x, y, x + dx, y + dy, mask);
   }
 
+  /**
+   * Returns whether a tile is exposed to the sky
+   * @param {number} x - x coordinate
+   * @param {number} y - y coordinate
+   * @returns {boolean} whether the tile is exposed to the sky
+   */
   _exposedToSky(x, y) {
     for (let i = y + 1; i < this.world.rows; i++) {
       if (!this.world.checkTile(x, i, ["AIR"])) return false;
@@ -294,10 +381,26 @@ class Worldlogic {
     return true;
   }
 
+  /**
+   * Returns the number of tiles matching the mask that are in reach
+   * @param {number} x - x coordinate
+   * @param {number} y - y coordinate
+   * @param {string[]} mask - tile types to check for
+   * @param {number} radius - radius to check (1 means only adjacent tiles)
+   * @returns {boolean} the number of matching tiles in reach
+   */
   _touching(x, y, mask, radius = 1) {
     return this._touchingWhich(x, y, mask, radius).length;
   }
 
+  /**
+   * Returns the tiles matching the mask that are in reach
+   * @param {number} x - x coordinate
+   * @param {number} y - y coordinate
+   * @param {string[]} mask - tile types to check for
+   * @param {number} radius - radius to check (1 means only adjacent tiles)
+   * @returns {object[]} list of matching tiles in reach as {x, y} objects
+   */
   _touchingWhich(x, y, mask, radius = 1) {
     // If no chunks in range contain target, skip searching
     const threshold = this.world.checkTile(x, y, mask) ? 2 : 1;
@@ -318,6 +421,14 @@ class Worldlogic {
     return touching;
   }
 
+  /**
+   * Sets one random tile matching the mask that is in reach to the given tile
+   * @param {number} x - x coordinate
+   * @param {number} y - y coordinate
+   * @param {string} tile - tile type to set
+   * @param {string[]} mask - tile types allowed to be replaced
+   * @returns {boolean} whether a tile was replaced
+   */
   _setOneTouching(x, y, tile, mask) {
     const targets = this._touchingWhich(x, y, mask);
     if (targets.length) {
@@ -327,6 +438,16 @@ class Worldlogic {
     return false;
   }
 
+  /**
+   * Move one step towards the nearest tile matching the target mask (if any are in range),
+   * switching places with the next tile in that direction
+   * @param {number} x - mover x coordinate
+   * @param {number} y - mover y coordinate
+   * @param {string[]} targetMask - tile types to move towards
+   * @param {number} radius - maximum search range
+   * @param {string[]} walkableMask - tile types that can be moved into
+   * @returns {boolean} whether the tile moved
+   */
   _searchForTile(x, y, targetMask, radius, walkableMask = ["AIR"]) {
     // If no chunks in range contain target, skip searching
     if (!this.world.checkChunks(x, y, targetMask, radius)) return false;

--- a/style.css
+++ b/style.css
@@ -32,7 +32,6 @@ body {
   border: solid gray 1px;
   display: block;
   margin: 0 auto;
-  aspect-ratio: 1;
   width: 100%;
 }
 


### PR DESCRIPTION
Worlds no longer have to be square and their dimensions can be modified via the browser console, taking effect when the game is reset.

CHUNK_SIZE can also be changed at any time and takes effect immediately.

You can use this to test performance on different-size maps and chunks without having to make code changes and reload the page.

In the browser console just type:
```
WORLD_COLS = [desired world width in tiles]
WORLD_ROWS = [desired world height in tiles]
CHUNK_SIZE = [desired chunk size in tiles, must be a common factor of WORLD_COLS and WORLD_ROWS]
```