### PR TITLE
implement swap tiles and fix legal function

### DIFF
--- a/script/world.js
+++ b/script/world.js
@@ -60,12 +60,6 @@ class World {
     }
   }
 
-  checkTile(x, y, mask) {
-    if (!this._legal(x, y)) return false;
-    if (!mask) return true;
-    return mask.includes(this.getTile(x, y));
-  }
-
   checkChunks(x, y, mask, distance = 0, threshold = 1) {
     if (!this._legal(x, y)) return false;
     if (!mask) return true;
@@ -143,6 +137,12 @@ class World {
       this.setTile(x, y, t2);
       return true;
     }
+  }
+
+  checkTile(x, y, mask) {
+    if (!this._legal(x, y)) return false;
+    if (!mask) return true;
+    return mask.includes(this.getTile(x, y));
   }
 
   forEachTile(minX, minY, maxX, maxY, func) {

--- a/src/world.rs
+++ b/src/world.rs
@@ -238,8 +238,25 @@ impl World {
         }
     }
 
-    fn swap_tiles(&self, _row1: i32, _col1: i32, _row2: i32, _col2: i32, _mask: Option<definitions::TileSet>) {
-        println!("swapTiles")
+    fn swap_tiles(
+        &mut self, 
+        x: &i32, 
+        y: &i32, 
+        a: &i32, 
+        b: &i32, 
+        mask: Option<&Vec<definitions::TileSet>>
+    ) -> bool {
+        if self.check_tile(&a, &b, mask) {
+            let t1 = self.get_tile(&x, &y).clone();
+            let t2 = self.get_tile(&a, &b).clone();
+            
+            self.set_tile(&a, &b, &t1, None);
+            self.set_tile(&x, &y, &t2, None);
+
+            true
+        } else {
+            false
+        }
     }
 
     fn for_each_tile<F>(
@@ -287,7 +304,7 @@ impl World {
     }
 
     fn legal(&self, x: &i32, y: &i32) -> bool {
-        x > &0 && y >= &0 && x < &self.cols && y < &self.rows
+        *x > 0 && *y >= 0 && *x < self.cols && *y < self.rows
     }
 
     fn benchmark(&self) {

--- a/src/worldgen.rs
+++ b/src/worldgen.rs
@@ -259,5 +259,4 @@ impl Worldgen {
         }
         0
     }
-
 }


### PR DESCRIPTION
swap tiles implemented

legal function fixed to compare dereferenced values not parameter reference values

moved checkTile so I could look at it next to swap tile 

I'm not 100% sure the logic of this checks out but I'm pretty sure it does, it's hard to replicate exact JS behaviour 